### PR TITLE
Include url params in canonical requests

### DIFF
--- a/spec/http_kit_aws4/http_kit_spec.clj
+++ b/spec/http_kit_aws4/http_kit_spec.clj
@@ -4,7 +4,6 @@
   (:import (org.joda.time DateTimeZone DateTime)))
 
 (describe "normalized-headers"
-
   (it "omits header with nil value"
     (should=
       [["x-not-borked" "foo"]]
@@ -13,7 +12,6 @@
 
 ;; https://docs.aws.amazon.com/general/latest/gr/signature-v4-test-suite.html#signature-v4-test-suite-example
 (describe "canonical-request"
-
   (it "A Simple GET Request with query-params"
     (let [expected "GET\n/\nParam1=value1&Param2=value2\nhost:example.amazonaws.com\nx-amz-date:20150830T123600Z\n\nhost;x-amz-date\ne3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"]
       (should=
@@ -24,6 +22,16 @@
                                       "Host" "example.amazonaws.com"}
                             :query-params {"Param2" "value2"
                                            "Param1" "value1"}}))))
+
+  (it "A Simple GET Request with url including query-params"
+      (let [expected "GET\n/\nParam1=value1&Param2=value2\nhost:example.amazonaws.com\nx-amz-date:20150830T123600Z\n\nhost;x-amz-date\ne3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"]
+        (should=
+          expected
+          (canonical-request {:url "http://example.amazonaws.com/?Param1=value1&Param2=value2"
+                              :method :get
+                              :headers {"X-Amz-Date" "20150830T123600Z"
+                                        "Host" "example.amazonaws.com"}}))))
+          
 
   (it "post-x-www-form-urlencoded"
     (let [expected "POST\n/\n\ncontent-type:application/x-www-form-urlencoded\ndate:Mon, 09 Sep 2011 23:36:00 GMT\nhost:host.foo.com\n\ncontent-type;date;host\n3ba8907e7a252327488df390ed517c45b96dead033600219bdca7107d1d3f88a"]

--- a/spec/http_kit_aws4/http_kit_spec.clj
+++ b/spec/http_kit_aws4/http_kit_spec.clj
@@ -32,6 +32,24 @@
                             :headers {"X-Amz-Date" "20150830T123600Z"
                                       "Host" "example.amazonaws.com"}}))))
 
+  (it "A Simple GET Request with url including query-params in the wrong order"
+    (let [expected "GET\n/\nParam1=value1&Param2=value2\nhost:example.amazonaws.com\nx-amz-date:20150830T123600Z\n\nhost;x-amz-date\ne3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"]
+      (should=
+        expected
+        (canonical-request {:url "http://example.amazonaws.com/?Param2=value2&Param1=value1"
+                            :method :get
+                            :headers {"X-Amz-Date" "20150830T123600Z"
+                                      "Host" "example.amazonaws.com"}}))))
+
+  (it "A Simple GET Request with a bad url"
+    (let [expected "GET\n/\n\nhost:example.amazonaws.com\nx-amz-date:20150830T123600Z\n\nhost;x-amz-date\ne3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"]
+      (should=
+        expected
+        (canonical-request {:url "http://example.amazonaws.com/??Param1=value1&&"
+                            :method :get
+                            :headers {"X-Amz-Date" "20150830T123600Z"
+                                      "Host" "example.amazonaws.com"}}))))
+
   (it "post-x-www-form-urlencoded"
     (let [expected "POST\n/\n\ncontent-type:application/x-www-form-urlencoded\ndate:Mon, 09 Sep 2011 23:36:00 GMT\nhost:host.foo.com\n\ncontent-type;date;host\n3ba8907e7a252327488df390ed517c45b96dead033600219bdca7107d1d3f88a"]
       (should=

--- a/spec/http_kit_aws4/http_kit_spec.clj
+++ b/spec/http_kit_aws4/http_kit_spec.clj
@@ -24,14 +24,13 @@
                                            "Param1" "value1"}}))))
 
   (it "A Simple GET Request with url including query-params"
-      (let [expected "GET\n/\nParam1=value1&Param2=value2\nhost:example.amazonaws.com\nx-amz-date:20150830T123600Z\n\nhost;x-amz-date\ne3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"]
-        (should=
-          expected
-          (canonical-request {:url "http://example.amazonaws.com/?Param1=value1&Param2=value2"
-                              :method :get
-                              :headers {"X-Amz-Date" "20150830T123600Z"
-                                        "Host" "example.amazonaws.com"}}))))
-          
+    (let [expected "GET\n/\nParam1=value1&Param2=value2\nhost:example.amazonaws.com\nx-amz-date:20150830T123600Z\n\nhost;x-amz-date\ne3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"]
+      (should=
+        expected
+        (canonical-request {:url "http://example.amazonaws.com/?Param1=value1&Param2=value2"
+                            :method :get
+                            :headers {"X-Amz-Date" "20150830T123600Z"
+                                      "Host" "example.amazonaws.com"}}))))
 
   (it "post-x-www-form-urlencoded"
     (let [expected "POST\n/\n\ncontent-type:application/x-www-form-urlencoded\ndate:Mon, 09 Sep 2011 23:36:00 GMT\nhost:host.foo.com\n\ncontent-type;date;host\n3ba8907e7a252327488df390ed517c45b96dead033600219bdca7107d1d3f88a"]

--- a/src/http_kit_aws4/http_kit.clj
+++ b/src/http_kit_aws4/http_kit.clj
@@ -24,12 +24,12 @@
 
 (defn- canonical-query-string [request]
   (if (:query-params request)
-      (->> (or (:query-params request) {})
-           (clojure.walk/stringify-keys)
-           (into (sorted-map))
-           (map (fn [[k v]] (str k "=" v)))
-           (str/join "&"))
-      (get-url-params (:url request))))
+    (->> (or (:query-params request) {})
+         (clojure.walk/stringify-keys)
+         (into (sorted-map))
+         (map (fn [[k v]] (str k "=" v)))
+         (str/join "&"))
+    (get-url-params (:url request))))
 
 (defn- normalized-headers [request]
   (->> (or (:headers request) {})

--- a/src/http_kit_aws4/http_kit.clj
+++ b/src/http_kit_aws4/http_kit.clj
@@ -8,6 +8,9 @@
   (:import [java.net URI]
            [javax.net.ssl SNIHostName SSLEngine SSLParameters]))
 
+(defn- get-url-params [url]
+  (second (str/split url #"\?")))
+
 (defn- http-request-method [request]
   (-> (:method request)
       (or :get)
@@ -20,11 +23,13 @@
     "/"))
 
 (defn- canonical-query-string [request]
-  (->> (or (:query-params request) {})
-       (clojure.walk/stringify-keys)
-       (into (sorted-map))
-       (map (fn [[k v]] (str k "=" v)))
-       (str/join "&")))
+  (if (:query-params request)
+      (->> (or (:query-params request) {})
+           (clojure.walk/stringify-keys)
+           (into (sorted-map))
+           (map (fn [[k v]] (str k "=" v)))
+           (str/join "&"))
+      (get-url-params (:url request))))
 
 (defn- normalized-headers [request]
   (->> (or (:headers request) {})


### PR DESCRIPTION
Proposal to solve #2 
If no :query-params are provided to the canonical-request function function, a split is done on the url in an attempt to isolate the query parameters.