### PR TITLE
GitHub Packages and jonase/eastwood upgrade

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,7 @@ sudo: false
 language: clojure
 lein: 2.6.1
 jdk:
-- openjdk10
+- openjdk11
 
 install: true
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,7 @@ sudo: false
 language: clojure
 lein: 2.6.1
 jdk:
-- oraclejdk8
+- oraclejdk10
 
 install: true
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,7 @@
 sudo: false
 language: clojure
-lein: 2.6.1
 jdk:
-- openjdk11
+- openjdk13
 
 install: true
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 sudo: false
 language: clojure
 jdk:
-- openjdk13
+- openjdk11
 
 install: true
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,7 @@ sudo: false
 language: clojure
 lein: 2.6.1
 jdk:
-- oraclejdk10
+- openjdk10
 
 install: true
 

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ for [org.httpkit.client/request](http://www.http-kit.org/client.html#options)
 In `project.clj`:
 ```clojure
  (defproject your-project
-   :repositories [["yle-public" "https://maven.yle.fi/release"]]
+   :repositories [["http-kit-aws4" "https://maven.pkg.github.com/yleisradio/http-kit-aws4"]]
    :dependencies [[http-kit-aws4 "0.2.0"]])
 ```
 

--- a/project.clj
+++ b/project.clj
@@ -22,12 +22,12 @@
   :plugins [[fi.yle.tools/aws-maven "1.4.2"]
             [speclj "3.3.2"]]
   :repositories [["yle-public" "https://maven.yle.fi/release"]]
-  :deploy-repositories [["releases" {:url           "https://maven.pkg.github.com/yleisradio/ovp-cljfmt"
+  :deploy-repositories [["releases" {:url           "https://maven.pkg.github.com/yleisradio/http-kit-aws4"
                                      :sign-releases false
                                      :snapshots     false
                                      :username      "yleisradio-travis-ci"
                                      :password      :env/github_token}]
-                        ["snapshots" {:url           "https://maven.pkg.github.com/yleisradio/ovp-cljfmt"
+                        ["snapshots" {:url           "https://maven.pkg.github.com/yleisradio/http-kit-aws4"
                                       :sign-releases false
                                       :snapshots     true
                                       :username      "yleisradio-travis-ci"

--- a/project.clj
+++ b/project.clj
@@ -25,12 +25,10 @@
   :deploy-repositories [["releases" {:url           "https://maven.pkg.github.com/yleisradio/http-kit-aws4"
                                      :sign-releases false
                                      :snapshots     false
-                                     :username      "yleisradio-travis-ci"
-                                     :password      :env/github_token}]
+                                     :creds         :gpg}]
                         ["snapshots" {:url           "https://maven.pkg.github.com/yleisradio/http-kit-aws4"
                                       :sign-releases false
                                       :snapshots     true
-                                      :username      "yleisradio-travis-ci"
-                                      :password      :env/github_token}]]
+                                      :creds         :gpg}]]
   :test-paths ["spec"]
   :aliases {"lint" ["with-profile" "dev" "do" ["cljfmt" "check"] ["eastwood"] ["kibit"]]})

--- a/project.clj
+++ b/project.clj
@@ -10,7 +10,7 @@
                  [clj-time "0.14.0"]
                  [http-kit "2.4.0-alpha3"]]
   :profiles {:dev {:dependencies [[speclj "3.3.2"]]
-                   :plugins [[jonase/eastwood "0.2.4"]
+                   :plugins [[jonase/eastwood "0.3.11"]
                              [lein-kibit "0.1.5"]
                              [lein-cljfmt "0.5.7"]]
                    :cljfmt {:indents {around   [[:inner 0]]

--- a/project.clj
+++ b/project.clj
@@ -22,15 +22,15 @@
   :plugins [[fi.yle.tools/aws-maven "1.4.2"]
             [speclj "3.3.2"]]
   :repositories [["yle-public" "https://maven.yle.fi/release"]]
-  :deploy-repositories [["releases" {:url           "s3://maven.c4.yle.fi/release"
+  :deploy-repositories [["releases" {:url           "https://maven.pkg.github.com/yleisradio/ovp-cljfmt"
                                      :sign-releases false
                                      :snapshots     false
-                                     :username      ""
-                                     :password      ""}]
-                        ["snapshots" {:url           "s3://maven.c4.yle.fi/snapshot"
+                                     :username      "yleisradio-travis-ci"
+                                     :password      :env/github_token}]
+                        ["snapshots" {:url           "https://maven.pkg.github.com/yleisradio/ovp-cljfmt"
                                       :sign-releases false
                                       :snapshots     true
-                                      :username      ""
-                                      :password      ""}]]
+                                      :username      "yleisradio-travis-ci"
+                                      :password      :env/github_token}]]
   :test-paths ["spec"]
   :aliases {"lint" ["with-profile" "dev" "do" ["cljfmt" "check"] ["eastwood"] ["kibit"]]})

--- a/src/http_kit_aws4/http_kit.clj
+++ b/src/http_kit_aws4/http_kit.clj
@@ -1,5 +1,7 @@
 (ns http-kit-aws4.http-kit
-  (:require [clojure.string :as string]
+  (:require [clojure.java.io]
+            [clojure.string :as string]
+            [clojure.walk]
             [buddy.core.codecs :as codecs]
             [buddy.core.hash :as hash]
             [http-kit-aws4.aws-credentials :refer [get-aws-credentials]]


### PR DESCRIPTION
Main changes:
- change deployment target to Github Packages
- remove version lock from `lein` to get rid of java.sql.Timestamp error
- upgrade jonase/eastwood to 0.3.11
- define missing namespaces in http_kit.clj