### PR TITLE
version 0.3.0: Cache AWS credentials for 60 seconds

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+## [0.3.0]
+### Fixed:
+- Issue #11 fixed by caching AWS credentials in memory for 60 seconds
+
 ## [0.2.0]
 ### Changed:
 - Update AWS Maven wagon version

--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject http-kit-aws4 "0.2.0"
+(defproject http-kit-aws4 "0.3.0-SNAPSHOT"
   :description "AWS Request Signing v4 for http-kit"
   :url "https://github.com/Yleisradio/http-kit-aws4"
   :license {:name "MIT License"

--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject http-kit-aws4 "0.3.0-SNAPSHOT"
+(defproject http-kit-aws4 "0.3.0"
   :description "AWS Request Signing v4 for http-kit"
   :url "https://github.com/Yleisradio/http-kit-aws4"
   :license {:name "MIT License"

--- a/project.clj
+++ b/project.clj
@@ -4,6 +4,7 @@
   :license {:name "MIT License"
             :url "http://www.opensource.org/licenses/mit-license.php"}
   :dependencies [[org.clojure/clojure "1.8.0"]
+                 [org.clojure/core.memoize "1.0.236"]
                  [buddy "2.0.0"]
                  [camel-snake-kebab "0.4.0"]
                  [cheshire "5.8.0"]

--- a/src/http_kit_aws4/aws_credentials.clj
+++ b/src/http_kit_aws4/aws_credentials.clj
@@ -1,5 +1,6 @@
 (ns http-kit-aws4.aws-credentials
   (:require [cheshire.core :as json]
+            [clojure.core.memoize :as memo]
             [org.httpkit.client :as http-client]
             [camel-snake-kebab.core :refer [->kebab-case-keyword]]))
 
@@ -22,7 +23,7 @@
    :secret-access-key  (System/getenv "AWS_SECRET_ACCESS_KEY")
    :token              (System/getenv "AWS_SESSION_TOKEN")})
 
-(defn get-aws-credentials
+(defn- get-aws-credentials!
   "Returns a map of AWS credentials provided by (in order of precedence)
   - AWS ECS Agent, via AWS_CONTAINER_CREDENTIALS_RELATIVE_URI, when running in an ECS container
   - environment variables AWS_ACCESS_KEY_ID etc"
@@ -30,3 +31,6 @@
   (if aws-container-credentials-url
     (get-aws-container-credentials aws-container-credentials-url)
     aws-environment-credentials))
+
+(def get-aws-credentials
+  (memo/ttl get-aws-credentials! :ttl/threshold 60000))


### PR DESCRIPTION
Attempts to fix #11 